### PR TITLE
Add latest PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 install:
   - docker --version
-  - docker login -u pypywheels -p $DOCKERPASS
+  - test -z "$DOCKERPASS" || docker login -u pypywheels -p $DOCKERPASS
   - ./docker/build_image.sh
   - pip install pytest
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -15,7 +15,7 @@ function _build_maybe() {
     then
         echo "pull failed, building it"
         docker build docker/$dir -t $image:$tag $extra_args || exit
-        if [ "$TRAVIS_PULL_REQUEST" = "false"]
+        if [ "$TRAVIS_PULL_REQUEST" = "false" ]
         then
             echo "skipping docker push because this is a PR"
         else

--- a/docker/image/install_pypy.sh
+++ b/docker/image/install_pypy.sh
@@ -4,6 +4,8 @@
 ALL_PYPYS=(
     pypy-5.8-1-linux_x86_64-portable.tar.bz2
     pypy-5.9-linux_x86_64-portable.tar.bz2
+    pypy3.5-5.8-1-beta-linux_x86_64-portable.tar.bz2
+    pypy3.5-5.9-beta-linux_x86_64-portable.tar.bz2
 )
 
 function install_pypy() {

--- a/docker/image/install_pypy.sh
+++ b/docker/image/install_pypy.sh
@@ -22,10 +22,6 @@ function install_pypy() {
 
     cd /opt
     tar xf /tmp/$PYPY
-    #
-    # add a symlink to /opt/pypy, so that it always contains the latest
-    # installed pypy
-    ln -sf $DIR pypy
 
     /opt/$DIR/bin/pypy -m ensurepip
     /opt/$DIR/bin/pypy -m pip install wheel

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -21,7 +21,7 @@ echo "Compiling wheels"
 echo "TARGETDIR: $TARGETDIR"
 echo
 cd
-for PYPY in /opt/pypy-*/bin/pypy
+for PYPY in /opt/pypy*/bin/pypy
 do
     echo "FOUND PYPY: $PYPY"
     # pip install using our own wheel repo: this ensures that we don't

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -11,7 +11,6 @@ TARGETDIR=/pypy-wheels/wheelhouse/$TARGET
 packages=(
     netifaces
     psutil
-    numpy
     scipy
     pandas
 )
@@ -21,6 +20,23 @@ echo "Compiling wheels"
 echo "TARGETDIR: $TARGETDIR"
 echo
 cd
+
+# First, NumPy wheels
+for PYPY in /opt/pypy*/bin/pypy
+do
+    echo "FOUND PYPY: $PYPY"
+    # pip install using our own wheel repo: this ensures that we don't
+    # recompile a package if the wheel is already available.
+    $PYPY -m pip install numpy \
+          --extra-index https://antocuni.github.io/pypy-wheels/$TARGET
+
+    $PYPY -m pip wheel numpy \
+          -w wheelhouse \
+          --extra-index https://antocuni.github.io/pypy-wheels/$TARGET
+    echo
+done
+
+# Then, the rest
 for PYPY in /opt/pypy*/bin/pypy
 do
     echo "FOUND PYPY: $PYPY"


### PR DESCRIPTION
From what I understand, the wheels are built against all the PyPys. I therefore propose to build them against PyPy3 as well.

I am hesitant on whether this will take too much time on Travis. Are you considering having parallel jobs that build wheels separately? One could even have one stage to build the Docker image, and then `N` later stages that would pull that image and build the wheels for each PyPy version.