### PR TITLE
Build scipy twice, not three times.

### DIFF
--- a/scripts/generate_jobs.py
+++ b/scripts/generate_jobs.py
@@ -13,7 +13,6 @@ PACKAGES = [
     'scipy',
     'cython',
     'cryptography netifaces psutil gevent',
-    'scipy',
     'pandas',
 ]
 


### PR DESCRIPTION
I think as-is this builds scipy three times -- twice unpinned (the other one on line 13), and then the one pinned one -- probably an oversight?